### PR TITLE
feature/zcs-1966 (upgrade doc)

### DIFF
--- a/imapd.adoc
+++ b/imapd.adoc
@@ -1,0 +1,26 @@
+= IMAPD Service
+
+
+Version {product-version} of {product-name} introduced a new
+`zimbra-imapd` service that allows you to run the IMAP[S]
+endpoints outside of the `mailboxd` process. This new service may be
+deployed on your mailbox servers or on stand-alone machines and it
+gives you the ability to scale IMAP separately from
+the mailboxes. This will also reduce the load on your mailbox servers.
+
+Although installation of the new `zimbra-imapd` is intended for larger
+multi-server installations, it is also fine to use with a
+single-server installation.
+
+Using `zimbra-imapd` on a single server means that 2 different JVMs will
+be used to service IMAP[S] requests instead of one, which means that each
+of them will use less memory which may improve garbage collection
+performance in each JVM. The separation will improve the robustness of
+the system. However, this needs to be balanced against the additional
+overhead of communication between the JVMs.
+
+Please refer to the _{product-admin-guide}_ for help with
+configuration.
+
+
+

--- a/upgrade.adoc
+++ b/upgrade.adoc
@@ -6,7 +6,8 @@ include::settings.adoc[]
 The following tasks might need to be performed before you
 upgrade. After you review the tasks in this section, go to Upgrade
 Instructions. Be sure to read the
-https://wiki.zimbra.com/index.php?title=Zimbra_Releases/8.7.0[release note] information before upgrading.
+https://wiki.zimbra.com/index.php?title=Zimbra_Releases/8.7.0[release note]
+information before upgrading.
 
 [NOTE]
 ====
@@ -20,6 +21,14 @@ compatible with 2FA.
 Accordingly, it is recommended that 2FA is not enabled until all
 mailbox servers have been upgraded to 8.7.
 ====
+
+The following new services are available for installation at upgrade
+time. Please refer to the _{product-admin-guide}_ for more information
+and to determine if you wish to install them.
+
+- `zimbra-chat`
+- `zimbra-drive`
+- `zimbra-imapd`
 
 === Database Integrity Checking
 

--- a/upgrade.adoc
+++ b/upgrade.adoc
@@ -485,7 +485,9 @@ httpclient_external_connmgr_tcp_nodelay
 include::ephemeral.adoc[]
 :leveloffset: -2
 
-
+:leveloffset: +2
+include::imapd.adoc[]
+:leveloffset: -2
 
 == Remove Current Version and Perform Clean Install of ZCS
 


### PR DESCRIPTION
## Summary

Added a small section to the upgrade documentation that introduces the new `zimbra-imapd` service.  In the same manner as we handled the ephemeral section, it defers configuration details to the admin guide. The additions to the admin guide are part of `ZCS-1963`.

## Sidebar Content

![sidebar](https://c1.staticflickr.com/5/4293/35911622101_54153f39af_b.jpg)

## Body Content, version 1
![body](https://c1.staticflickr.com/5/4310/35911622161_8cf08269fd_b.jpg)

## Body Content, version 2
![body2](https://c1.staticflickr.com/5/4305/35916450041_6c201eb0a9_b.jpg)

## Before Upgrade
![before-upgrade](https://c1.staticflickr.com/5/4304/35879691592_789292d5d3_b.jpg)